### PR TITLE
Use Python 2.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 
 language: python
+python: "2.7"
 
 env:
   - GUEST_OS=ubuntu-16.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,10 @@ before_install:
   - sudo apt-get -y --force-yes install linux-headers-`uname -r`
   # Install VirtualBox 5.2
   - sudo apt-get install virtualbox-5.2
-  # Install Vagrant 2.2.0
+  # Install Vagrant 2.2.4
   # Todo: install from a package repository, not from a hardcoded URL.
-  - curl -O https://releases.hashicorp.com/vagrant/2.2.0/vagrant_2.2.0_x86_64.deb
-  - sudo dpkg -i vagrant_2.2.0_x86_64.deb
+  - curl -O https://releases.hashicorp.com/vagrant/2.2.4/vagrant_2.2.4_x86_64.deb
+  - sudo dpkg -i vagrant_2.2.4_x86_64.deb
 
 install:
   - composer install --no-interaction --no-progress --no-suggest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Draft Environment 3.x.x
 
+- [GH-98](https://github.com/lemberg/draft-environment/issues/98) - Fix broken Travis CI; update Vagrant to version 2.2.4 on Travis CI
 - [GH-82](https://github.com/lemberg/draft-environment/issues/82) - Ensure that PasswordAuthentication and ChallengeResponseAuthentication are enabled. See https://serverfault.com/questions/98289/ssh-doesnt-ask-for-password-gives-permission-denied-immediately
 - [GH-81](https://github.com/lemberg/draft-environment/issues/81) - Fixed Ansible warning:
 


### PR DESCRIPTION
See https://changelog.travis-ci.com/the-default-python-version-for-your-builds-is-now-3-6-97935

Closes #98 