### PR TITLE
Prevent PHP fatal error when downgrading to 3.0.0-beta4 or earlier

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -119,7 +119,15 @@ final class App {
   private function onPostPackageUpdate(UpdateOperation $operation): void {
     // Update Draft Environment configuration upon package update.
     if ($operation->getTargetPackage()->getName() === self::PACKAGE_NAME) {
-      $this->configUpdateManager->update();
+      // Release date may be empty in rare cases. Assume the latest
+      // version is being used.
+      $now = new \DateTime();
+      $initialReleaseDate = $operation->getInitialPackage()->getReleaseDate() ?? $now;
+      $targetReleaseDate = $operation->getTargetPackage()->getReleaseDate() ?? $now;
+      // Package downgrading is not supported by the update manager.
+      if ($targetReleaseDate >= $initialReleaseDate) {
+        $this->configUpdateManager->update();
+      }
     }
   }
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -197,6 +197,23 @@ final class AppTest extends TestCase {
   /**
    * Tests Composer PackageEvents::POST_PACKAGE_UPDATE event handler.
    */
+  public function testComposerPostPackageUpdateEventHandlerDoesNotRunWhenDowngrading(): void {
+    // Update must run when "lemberg/draft-environment" is being updated.
+    $initial = new Package(App::PACKAGE_NAME, '1.0.0.0', '^1.0');
+    $initial->setReleaseDate(new \DateTime());
+    $target = new Package(App::PACKAGE_NAME, '1.2.0.0', '^1.0');
+    $target->setReleaseDate(new \DateTime('yesterday'));
+    $operation = new UpdateOperation($initial, $target);
+    $event = new PackageEvent(PackageEvents::POST_PACKAGE_UPDATE, $this->composer, $this->io, FALSE, $this->policy, $this->pool, $this->installedRepo, $this->request, [$operation], $operation);
+    $this->configUpdateManager
+      ->expects(self::never())
+      ->method('update');
+    $this->app->handleEvent($event);
+  }
+
+  /**
+   * Tests Composer PackageEvents::POST_PACKAGE_UPDATE event handler.
+   */
   public function testComposerPostPackageUpdateEventHandlerDoesRun(): void {
     // Update must run when "lemberg/draft-environment" is being updated.
     $initial = new Package(App::PACKAGE_NAME, '1.0.0.0', '^1.0');


### PR DESCRIPTION
Closes #145 