### PR TITLE
Make sure geerlingguy.mysql role is installable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## Draft Environment 3.x.x (unreleased)
 
 Updates:
+
 - [GH-161](https://github.com/lemberg/draft-environment/issues/161) - Updated Ansible MySQL role to 3.0.0
 - [GH-159](https://github.com/lemberg/draft-environment/issues/159) - Upgraded Molecule framework (2 => 3)
 - [GH-157](https://github.com/lemberg/draft-environment/issues/157) - Switched to unofficial PPA for Vagrant on Travis; Vagrant 2.2.7 supports VirtualBox 6.1.x
+
+Fixes:
+
+- [GH-168](https://github.com/lemberg/draft-environment/issues/168) - Ansible role geerlingguy.mysql @ 3.0.0 was failing to install due to incorrect python configuration in certain cases (fixed by setting `ansible_python_interpreter` to `/usr/bin/python3`
 
 ## Draft Environment 3.0.0-rc2, 2020-02-12
 

--- a/default.vm-settings.yml
+++ b/default.vm-settings.yml
@@ -127,7 +127,7 @@ apache2_document_root: docroot
 # Log level to use
 apache2_log_level: error
 
-# Role: geerlingguy.mysql @ 2.9.5
+# Role: geerlingguy.mysql @ 3.0.0
 
 # Set this to the user ansible is logging in as - should have root
 # or sudo access

--- a/default.vm-settings.yml
+++ b/default.vm-settings.yml
@@ -162,7 +162,7 @@ mysql_packages:
   - mysql-server
 
 # If you need to explicitly set the MySQL Python package, you can set it here. If not set, it will default to `python-mysqldb` for Python 2 and `python3-mysqldb` for Python 3.
-mysql_python_package_debian: ''
+# mysql_python_package_debian: ''
 
 # MySQL connection settings.
 mysql_port: "3306"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -51,11 +51,13 @@
     - ../../provisioning/roles/draft
     - ../../provisioning/roles/git_config
     - ../../provisioning/roles/apache2
-    - { role: geerlingguy.mysql, mysql_python_package_debian: python3-mysqldb }
+    - geerlingguy.mysql
     - geerlingguy.mailhog
     - T2L.php
     - T2L.composer
     - T2L.java
     - { role: T2L.solr, solr_cleanup_downloads: false, solr_cleanup_gpg: false }
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   vars_files:
     - ../../default.vm-settings.yml

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -13,3 +13,6 @@
     - { role: T2L.composer, when: "'composer' in draft_features" }
     - { role: T2L.java, when: "'java' in draft_features" }
     - { role: T2L.solr, when: "'solr' in draft_features" }
+
+  vars:
+    ansible_python_interpreter: /usr/bin/python3

--- a/provisioning/roles/draft/tasks/main.yml
+++ b/provisioning/roles/draft/tasks/main.yml
@@ -49,8 +49,8 @@
     name:
       - libxml2-dev
       - libxslt-dev
-      - python-dev
-      - python-lxml
+      - python3-dev
+      - python3-lxml
       - rsync
     state: present
   when: "'solr' in draft_features"


### PR DESCRIPTION
Fix:
```
  TASK [geerlingguy.mysql : Ensure MySQL Python libraries are installed.]
  fatal: [roma]: FAILED! => {"changed": false, "msg": "No package matching '' is available"}
```
Closes #168 