### PR TITLE
#198 Fix package settings gets deleted from the composer.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Draft Environment 3.x.x (Unreleased)
+
+Fixes:
+
+- [GH-198](https://github.com/lemberg/draft-environment/issues/198) - Fix package settings gets deleted from the composer.lock when running any arbitrary composer command
+
 ## Draft Environment 3.0.0, 2020-04-27
 
 Updates:

--- a/src/App.php
+++ b/src/App.php
@@ -171,18 +171,19 @@ final class App {
   private function onPostAutoloadDumpCommand(ScriptEvent $event): void {
     if ($this->shouldRunInstallation) {
       $this->configInstallManager->install();
-
-      // Fresh installation should mark all available updates as already
-      // applied.
-      $lastAvailableWeight = $this->configUpdateManager->getLastAvailableUpdateWeight();
-      $this->configUpdateManager->setLastAppliedUpdateWeight($lastAvailableWeight);
+      $this->shouldRunInstallation = FALSE;
     }
-    $this->shouldRunInstallation = FALSE;
 
     if ($this->shouldRunUpdate) {
       $this->configUpdateManager->update();
+      $this->shouldRunUpdate = FALSE;
     }
-    $this->shouldRunUpdate = FALSE;
+
+    // Mark the package as already installed.
+    $this->configInstallManager->setAsAlreadyInstalled();
+    // Mark all available updates as already applied.
+    $lastAvailableWeight = $this->configUpdateManager->getLastAvailableUpdateWeight();
+    $this->configUpdateManager->setLastAppliedUpdateWeight($lastAvailableWeight);
   }
 
 }


### PR DESCRIPTION
… when running any arbitrary composer commands

Closes #198 