### PR TITLE
Ensure that plugin does not throw PHP fatal errors when lemberg/draft-environment package is not present (anymore/yet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Fixes:
 
+- [GH-205](https://github.com/lemberg/draft-environment/issues/205) - Fix PHP fatal error upon package removal (i.e. when running `composer remove lemberg/draft-environment`
 - [GH-208](https://github.com/lemberg/draft-environment/issues/208) - Fix broken provisioning by adding `/vagrant` mount
 
 ## Draft Environment 3.1.0, 2020-08-06

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,7 @@ parameters:
       - Lemberg\Draft\Environment\Config\Manager\AbstractConfigManager
       - Lemberg\Draft\Environment\Config\Install\Step\AbstractInstallStep
       - Lemberg\Draft\Environment\Config\Update\Step\AbstractUpdateStep
+      - Lemberg\Tests\Functional\Draft\Environment\AbstractFunctionalTest
       - Lemberg\Tests\Functional\Draft\Environment\Config\Manager\AbstractConfigManagerTest
       - Symfony\Component\Filesystem\Filesystem
   ignoreErrors:
@@ -15,4 +16,3 @@ parameters:
       message: '#Method [A-Za-z0-9\\]+::[A-Za-z0-9\(\)]+ is not final, but since the containing class is abstract, it should be.#'
       paths:
         - src/Config/Install/Step/AbstractInstallStep.php
-        - tests/Functional/Config/Manager/AbstractConfigManagerTest.php

--- a/src/Config/Manager/AbstractConfigManager.php
+++ b/src/Config/Manager/AbstractConfigManager.php
@@ -89,9 +89,9 @@ abstract class AbstractConfigManager implements ManagerInterface {
    */
   final protected function getPackageExtra(): array {
     $localRepository = $this->composer->getRepositoryManager()->getLocalRepository();
-    /** @var \Composer\Package\Package $localPackage */
+    /** @var \Composer\Package\Package|NULL $localPackage */
     $localPackage = $localRepository->findPackage(App::PACKAGE_NAME, '*');
-    return $localPackage->getExtra();
+    return !is_null($localPackage) ? $localPackage->getExtra() : [];
   }
 
   /**
@@ -99,9 +99,11 @@ abstract class AbstractConfigManager implements ManagerInterface {
    */
   final protected function setPackageExtra(array $extra): void {
     $localRepository = $this->composer->getRepositoryManager()->getLocalRepository();
-    /** @var \Composer\Package\Package $localPackage */
+    /** @var \Composer\Package\Package|NULL $localPackage */
     $localPackage = $localRepository->findPackage(App::PACKAGE_NAME, '*');
-    $localPackage->setExtra($extra);
+    if (!is_null($localPackage)) {
+      $localPackage->setExtra($extra);
+    }
 
     // This code might run after Composer has written the lock file.
     $composerFile = Factory::getComposerFile();

--- a/tests/Functional/AbstractFunctionalTest.php
+++ b/tests/Functional/AbstractFunctionalTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lemberg\Tests\Functional\Draft\Environment;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Base functional test.
+ *
+ * @coversNothing
+ */
+abstract class AbstractFunctionalTest extends TestCase {
+
+  /**
+   * @var string
+   */
+  protected $workingDir;
+
+  /**
+   * @var \Symfony\Component\Filesystem\Filesystem
+   */
+  protected $fs;
+
+  /**
+   * @var string
+   */
+  protected $basePath;
+
+  /**
+   * {@inheritdoc}
+   */
+  final protected function setUp(): void {
+
+    $this->workingDir = sys_get_temp_dir() . '/draft-environment';
+
+    $this->fs = new Filesystem();
+    $this->fs->remove($this->workingDir);
+    $this->fs->mkdir($this->workingDir);
+
+    // Build path to the test composer.json file based on the current class
+    // name.
+    $this->basePath = './tests/fixtures/Functional' . str_replace('\\', DIRECTORY_SEPARATOR, substr(static::class, strlen('Lemberg\Tests\Functional\Draft\Environment')));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  final protected function tearDown(): void {
+    $this->fs->remove($this->workingDir);
+
+    parent::tearDown();
+  }
+
+}

--- a/tests/Functional/AppTest.php
+++ b/tests/Functional/AppTest.php
@@ -2,22 +2,24 @@
 
 declare(strict_types=1);
 
-namespace Lemberg\Tests\Functional\Draft\Environment\Config\Manager;
+namespace Lemberg\Tests\Functional\Draft\Environment;
 
+use Lemberg\Draft\Environment\App;
 use Symfony\Component\Process\Process;
 
 /**
- * Tests Draft Environment configuration install manager.
+ * Tests Draft Environment installation and removal.
  *
  * @coversNothing
  */
-final class InstallManagerTest extends AbstractConfigManagerTest {
+final class AppTest extends AbstractFunctionalTest {
 
   /**
-   * Tests that package installation does set up correct data in the package
-   * extra.
+   * Tests that package installation and removal works as expected.
+   *
+   * @doesNotPerformAssertions
    */
-  public function testComposerInstall(): void {
+  public function testComposerInstallAndRemove(): void {
 
     $this->fs->mirror($this->basePath, $this->workingDir, NULL, ['override' => TRUE]);
 
@@ -46,7 +48,13 @@ final class InstallManagerTest extends AbstractConfigManagerTest {
     ]))
       ->mustRun();
 
-    $this->assertComposerLockContainsPackageExtra();
+    // Run composer remove.
+    (new Process([
+      'vendor/bin/composer', 'remove',
+      '--dev', App::PACKAGE_NAME,
+      '--working-dir', $this->workingDir,
+    ]))
+      ->mustRun();
   }
 
 }

--- a/tests/Functional/Config/Manager/AbstractConfigManagerTest.php
+++ b/tests/Functional/Config/Manager/AbstractConfigManagerTest.php
@@ -6,42 +6,14 @@ namespace Lemberg\Tests\Functional\Draft\Environment\Config\Manager;
 
 use Composer\Json\JsonFile;
 use Lemberg\Draft\Environment\App;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Filesystem\Filesystem;
+use Lemberg\Tests\Functional\Draft\Environment\AbstractFunctionalTest;
 
 /**
  * Base configuration manager test.
  *
  * @coversNothing
  */
-abstract class AbstractConfigManagerTest extends TestCase {
-
-  /**
-   * @var string
-   */
-  protected $workingDir;
-
-  /**
-   * @var \Symfony\Component\Filesystem\Filesystem
-   */
-  protected $fs;
-
-  /**
-   * @var string
-   */
-  protected $basePath;
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function setUp(): void {
-
-    $this->workingDir = sys_get_temp_dir() . '/draft-environment';
-
-    $this->fs = new Filesystem();
-    $this->fs->remove($this->workingDir);
-    $this->fs->mkdir($this->workingDir);
-  }
+abstract class AbstractConfigManagerTest extends AbstractFunctionalTest {
 
   /**
    * Asserts that composer.lock exists and contains correct data in the package
@@ -57,15 +29,6 @@ abstract class AbstractConfigManagerTest extends TestCase {
 
     self::assertTrue($decoded_composer_lock['packages-dev'][$key]['extra']['draft-environment']['already-installed']);
     self::assertSame(5, $decoded_composer_lock['packages-dev'][$key]['extra']['draft-environment']['last-update-weight']);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  final protected function tearDown(): void {
-    $this->fs->remove($this->workingDir);
-
-    parent::tearDown();
   }
 
 }

--- a/tests/Functional/Config/Manager/ConfigManagerTest.php
+++ b/tests/Functional/Config/Manager/ConfigManagerTest.php
@@ -15,16 +15,6 @@ use Symfony\Component\Process\Process;
 final class ConfigManagerTest extends AbstractConfigManagerTest {
 
   /**
-   * {@inheritdoc}
-   */
-  protected function setUp(): void {
-    parent::setUp();
-
-    // Build path to the test composer.json file based on this class name.
-    $this->basePath = './tests/fixtures/Functional' . str_replace('\\', DIRECTORY_SEPARATOR, substr(__CLASS__, strlen('Lemberg\Tests\Functional\Draft\Environment')));
-  }
-
-  /**
    * Tests that package update does set up correct data in the package extra.
    *
    * @param string $directory

--- a/tests/Unit/Config/Manager/AbstractConfigManagerTest.php
+++ b/tests/Unit/Config/Manager/AbstractConfigManagerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lemberg\Tests\Unit\Draft\Environment\Config\Manager;
+
+use Composer\Composer;
+use Composer\Config as ComposerConfig;
+use Composer\Factory;
+use Composer\IO\IOInterface;
+use Composer\Json\JsonFile;
+use Composer\Package\RootPackage;
+use Composer\Repository\RepositoryManager;
+use Lemberg\Draft\Environment\App;
+use Lemberg\Draft\Environment\Config\Config;
+use Lemberg\Draft\Environment\Config\Manager\InstallManager;
+use Lemberg\Draft\Environment\Config\Manager\UpdateManager;
+use Lemberg\Draft\Environment\Utility\Filesystem;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests Draft Environment abstract configuration manager.
+ *
+ * @link https://github.com/lemberg/draft-environment/issues/205
+ *
+ * @covers \Lemberg\Draft\Environment\Config\Manager\AbstractConfigManager
+ */
+final class AbstractConfigManagerTest extends TestCase {
+
+  /**
+   * @var \Composer\Composer
+   */
+  private $composer;
+
+  /**
+   * @var \Composer\IO\IOInterface
+   */
+  private $io;
+
+  /**
+   * @var string
+   */
+  private $root;
+
+  /**
+   * @var \Lemberg\Draft\Environment\Utility\Filesystem
+   */
+  private $fs;
+
+  /**
+   * @var string
+   */
+  private $lockFile;
+
+  /**
+   * @var \Lemberg\Draft\Environment\Config\Manager\InstallManagerInterface
+   */
+  private $configInstallManager;
+
+  /**
+   * @var \Lemberg\Draft\Environment\Config\Manager\UpdateManagerInterface
+   */
+  private $configUpdateManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    $this->composer = new Composer();
+    $this->composer->setConfig(new ComposerConfig());
+    $package = new RootPackage('dummy/root-package', '^3.0', '3.0.0.0');
+    $this->composer->setPackage($package);
+    $manager = $this->getMockBuilder(RepositoryManager::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods([
+        'getLocalRepository',
+        'findPackage',
+      ])
+      ->getMock();
+    $manager->expects(self::any())
+      ->method('getLocalRepository')
+      ->willReturnSelf();
+    $manager->expects(self::any())
+      ->method('findPackage')
+      ->with(App::PACKAGE_NAME, '*')
+      ->willReturn(NULL);
+    $this->composer->setRepositoryManager($manager);
+    $this->io = $this->createMock(IOInterface::class);
+
+    // Mock source and target configuration directories.
+    $this->root = vfsStream::setup()->url();
+    $this->fs = new Filesystem();
+    $this->fs->mkdir(
+      ["$this->root/source", "$this->root/target", "$this->root/wd"]
+    );
+
+    // Point composer to a test composer.json.
+    putenv("COMPOSER=$this->root/wd/composer.json");
+
+    // Dump composer.lock.
+    $composerFile = Factory::getComposerFile();
+    $this->lockFile = 'json' === pathinfo($composerFile, PATHINFO_EXTENSION) ? substr($composerFile, 0, -4) . 'lock' : $composerFile . '.lock';
+    $json = new JsonFile($this->lockFile);
+    $lockData = [
+      'packages' => [
+        [
+          'name' => 'dummy/package',
+          'extra' => [],
+        ],
+        [
+          'name' => 'dummy/package-two',
+          'extra' => [],
+        ],
+      ],
+    ];
+    $json->write($lockData);
+
+    $config = new Config("$this->root/source", "$this->root/target");
+    $this->configInstallManager = new InstallManager($this->composer, $this->io, $config);
+    $this->configUpdateManager = new UpdateManager($this->composer, $this->io, $config);
+  }
+
+  /**
+   * Tests ::hasBeenAlreadyInstalled() and ::setAsAlreadyInstalled().
+   */
+  public function testHasBeenAlreadyInstalledFlagWithoutPackage(): void {
+    self::assertFalse($this->configInstallManager->hasBeenAlreadyInstalled());
+    $this->configInstallManager->setAsAlreadyInstalled();
+    self::assertFalse($this->configInstallManager->hasBeenAlreadyInstalled());
+  }
+
+  /**
+   * Tests ::getLastAppliedUpdateWeight() and ::setLastAppliedUpdateWeight().
+   */
+  public function testGetAndSetLastAppliedUpdateWeightWithoutPackage(): void {
+    self::assertSame(0, $this->configUpdateManager->getLastAppliedUpdateWeight());
+    $this->configUpdateManager->setLastAppliedUpdateWeight(4);
+    self::assertSame(0, $this->configUpdateManager->getLastAppliedUpdateWeight());
+  }
+
+}

--- a/tests/fixtures/Functional/AppTest/composer.json
+++ b/tests/fixtures/Functional/AppTest/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "lemberg/draft-environment-test",
+    "type": "project",
+    "description": "Test project that using lemberg/draft-environment",
+    "license": "GPL-2.0-or-later",
+    "require-dev": {
+        "lemberg/draft-environment": "@dev"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}


### PR DESCRIPTION
Closes #205 